### PR TITLE
remove .env configuration from Readme.md

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,37 @@
+VERSION=2.0.0
+# Environment Variable (TEST:DEV/MAIN:PROD)
+BIT_ENVIRONMENT=DEV
+### SERVER MODES - PROD: Live/Staging Servers, DEV: Global Dev Servers, LOCAL: Local Dev Servers
+BIT_SERVER_MODE=DEV
+# API URLs
+# RELAY and SIGNING SERVER URL
+BIT_API_URLS_RELAY=https://dev-relay.bithyve.com/
+BIT_API_URLS_SIGNING_SERVER=https://dev-sign.bithyve.com/
+BIT_HEXA_ID=b01623f1065ba45d68b516efe2873f59bfc9b9b2d8b194f94f989d87d711830a
+## Indexer Endpoints
+BIT_TESTNET_BASE_URL=https://test-wrapper.bithyve.com
+BIT_MAINNET_BASE_URL=https://api.bithyve.com
+## HEALTH TIME SLOTS
+### in minutes, 5 for dev and 20160(2 weeks) for live
+BIT_SHARE_HEALTH_TIME_SLOT1=5
+### in minutes, 10 for dev and 40320(4 weeks) for live
+BIT_SHARE_HEALTH_TIME_SLOT2=10
+NOTIFICATION_HOUR=2
+## FAST BITCOINS
+WALLET_SLUG=hexa
+FBTC_REGISTRATION_URL=https://fb-web-dev.aao-tech.com/create-account/hexa
+FBTC_URL=https://wallet-api-test.fastbitcoins.com/v2/
+##
+RAMP_BASE_URL=https://buy.ramp.network/
+RAMP_REFERRAL_CODE=ku67r7oh5juc27bmb3h5pek8y5heyb5bdtfa66pr
+## SWAN
+SWAN_CLIENT_ID=hexa-dev
+SWAN_BASE_URL=https://dev-api.swanbitcoin.com
+SWAN_URL_PREFIX=/apps/v20210824/
+SWAN_REDIRECT_URL=https%3A%2F%2Fdev-relay.bithyve.com%2FdeepLink%2Fdev%2Fswan%2F
+APP_ID=io.hexawallet.hexa.development
+APPLE_APP_ID=1507772462
+
+
+
+

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Then, from the command prompt, run:
 setup.bat
 ```
 
-### Configuring Environment Variables
+<!-- ### Configuring Environment Variables
 
 **Mainnet configuration**
 
@@ -47,7 +47,7 @@ Copy the contents on `.env.example` to a new `.env` file.
 
 ```sh
 cp .env.example .env
-```
+``` -->
 
 
 ## Building and Running Hexa Wallet


### PR DESCRIPTION
.env is not required to run/build dev app. you can run the app without.env, code will automatically pick dev environment.